### PR TITLE
Update mvscmd.js

### DIFF
--- a/examples/mvscmd/mvscmd.js
+++ b/examples/mvscmd/mvscmd.js
@@ -142,7 +142,7 @@ async function testExecuteAuthorizedOutputToPDSMember() {
   let res = await mvscmd._executeAuthorized('IDCAMS', '', dds);
   console.log(`res = ${JSON.stringify(res)}\n`);
   assert.equal(res['rc'], 0); // if no catalog, rc would be 4
-  let contents = await dataset.read(`'${dsn}(MEM1)'`);
+  let contents = await dataset.read(`${dsn}(MEM1)`);
   assert.equal(contents.includes('THE NUMBER OF ENTRIES PROCESSED WAS'), true);
 }
 


### PR DESCRIPTION
Removed redundant quotes at line 145 due to error on read.  The error message shows the dataset name wrapped in two sets of single quotes.